### PR TITLE
Add configurable rewards to FrozenLakeEnv

### DIFF
--- a/gymnasium/envs/toy_text/frozen_lake.py
+++ b/gymnasium/envs/toy_text/frozen_lake.py
@@ -226,6 +226,10 @@ class FrozenLakeEnv(Env):
         desc=None,
         map_name="4x4",
         is_slippery=True,
+        ##### NEW ARGS #####
+        reward_goal=1.0,
+        reward_hole=-1.0,
+        reward_step=-0.001
     ):
         if desc is None and map_name is None:
             desc = generate_random_map()
@@ -234,6 +238,11 @@ class FrozenLakeEnv(Env):
         self.desc = desc = np.asarray(desc, dtype="c")
         self.nrow, self.ncol = nrow, ncol = desc.shape
         self.reward_range = (0, 1)
+        
+        ##### MAKE REWARDS CLASS VARIABLE #####
+        self.reward_goal = reward_goal
+        self.reward_hole = reward_hole
+        self.reward_step = reward_step
 
         nA = 4
         nS = nrow * ncol
@@ -262,7 +271,15 @@ class FrozenLakeEnv(Env):
             new_state = to_s(new_row, new_col)
             new_letter = desc[new_row, new_col]
             terminated = bytes(new_letter) in b"GH"
-            reward = float(new_letter == b"G")
+            ##### CHANGE DEFAULT REWARDS #####
+            # reward = float(new_letter == b"G")
+            if new_letter == b"G":
+                reward = self.reward_goal
+            elif new_letter == b"H":
+                reward = self.reward_hole
+            else:
+                reward = self.reward_step
+
             return new_state, reward, terminated
 
         for row in range(nrow):

--- a/gymnasium/envs/toy_text/frozen_lake.py
+++ b/gymnasium/envs/toy_text/frozen_lake.py
@@ -227,7 +227,7 @@ class FrozenLakeEnv(Env):
         is_slippery=True,
         reward_goal=1.0,
         reward_hole=0.0,
-        reward_step=-0.0
+        reward_step=-0.0,
     ):
         if desc is None and map_name is None:
             desc = generate_random_map()
@@ -235,8 +235,11 @@ class FrozenLakeEnv(Env):
             desc = MAPS[map_name]
         self.desc = desc = np.asarray(desc, dtype="c")
         self.nrow, self.ncol = nrow, ncol = desc.shape
-        
-        self.reward_range = (min(reward_goal, reward_hole, reward_step), max(reward_goal, reward_hole, reward_step))
+
+        self.reward_range = (
+            min(reward_goal, reward_hole, reward_step),
+            max(reward_goal, reward_hole, reward_step),
+        )
         self.reward_goal = reward_goal
         self.reward_hole = reward_hole
         self.reward_step = reward_step

--- a/gymnasium/envs/toy_text/frozen_lake.py
+++ b/gymnasium/envs/toy_text/frozen_lake.py
@@ -125,11 +125,10 @@ class FrozenLakeEnv(Env):
     The episode starts with the player in state `[0]` (location [0, 0]).
 
     ## Rewards
-
-    Reward schedule:
-    - Reach goal: +1
-    - Reach hole: 0
-    - Reach frozen: 0
+    The rewards given at each state can be overridden by passing into the constructor:
+    - Reach goal default: +1.0
+    - Reach hole default: 0.0
+    - Reach frozen default: 0.0
 
     ## Episode End
     The episode ends if the following happens:
@@ -153,7 +152,7 @@ class FrozenLakeEnv(Env):
 
     ```python
     import gymnasium as gym
-    gym.make('FrozenLake-v1', desc=None, map_name="4x4", is_slippery=True)
+    gym.make('FrozenLake-v1', desc=None, map_name="4x4", is_slippery=True, )
     ```
 
     `desc=None`: Used to specify maps non-preloaded maps.
@@ -172,7 +171,7 @@ class FrozenLakeEnv(Env):
     ```
     from gymnasium.envs.toy_text.frozen_lake import generate_random_map
 
-    gym.make('FrozenLake-v1', desc=generate_random_map(size=8))
+    gym.make('FrozenLake-v1', desc=generate_random_map(size=8), reward_goal=1.0, reward_hole=0.0, reward_step=-0.0)
     ```
 
     `map_name="4x4"`: ID to use any of the preloaded maps.
@@ -226,10 +225,9 @@ class FrozenLakeEnv(Env):
         desc=None,
         map_name="4x4",
         is_slippery=True,
-        ##### NEW ARGS #####
         reward_goal=1.0,
-        reward_hole=-1.0,
-        reward_step=-0.001
+        reward_hole=0.0,
+        reward_step=-0.0
     ):
         if desc is None and map_name is None:
             desc = generate_random_map()
@@ -237,9 +235,8 @@ class FrozenLakeEnv(Env):
             desc = MAPS[map_name]
         self.desc = desc = np.asarray(desc, dtype="c")
         self.nrow, self.ncol = nrow, ncol = desc.shape
-        self.reward_range = (0, 1)
         
-        ##### MAKE REWARDS CLASS VARIABLE #####
+        self.reward_range = (min(reward_goal, reward_hole, reward_step), max(reward_goal, reward_hole, reward_step))
         self.reward_goal = reward_goal
         self.reward_hole = reward_hole
         self.reward_step = reward_step
@@ -271,7 +268,6 @@ class FrozenLakeEnv(Env):
             new_state = to_s(new_row, new_col)
             new_letter = desc[new_row, new_col]
             terminated = bytes(new_letter) in b"GH"
-            ##### CHANGE DEFAULT REWARDS #####
             # reward = float(new_letter == b"G")
             if new_letter == b"G":
                 reward = self.reward_goal


### PR DESCRIPTION
# Description

This branch adds three new init parameters to FrozenLakeEnv—`reward_goal`, `reward_hole`, and `reward_step`—so users can define custom reward schemes (e.g., -1 for hole, -0.01 per move, +1 for goal). The environment’s `reward_range` is now computed from these values, and defaults preserve original behavior.

Fixes #1364

- Added in the ability to assign custom reinforcements (rewards) for different actions in frozen lake, such as falling in a hole and regular movement.
- Reward range dynamically adjusts to the custom rewards.
- Extended docstring with usage examples
- Added unit tests for custom reward settings

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Screenshots

N/A

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes