### PR TITLE
Custom slip probabilities

### DIFF
--- a/gymnasium/envs/toy_text/frozen_lake.py
+++ b/gymnasium/envs/toy_text/frozen_lake.py
@@ -201,11 +201,11 @@ class FrozenLakeEnv(Env):
     <a id="is_slippy"></a>`is_slippery=True`: If true, each move is stochastic according
     to three user-settable probabilities:
 
-    - 'chance_correct_action': probability of moving in the intended direction  
-    - 'chance_slip_l': probability of slipping to the action that is “left” (counter-clockwise) of the intended  
-    - 'chance_slip_r': probability of slipping to the action that is “right” (clockwise) of the intended  
+    - 'chance_correct_action': probability of moving in the intended direction
+    - 'chance_slip_l': probability of slipping to the action that is “left” (counter-clockwise) of the intended
+    - 'chance_slip_r': probability of slipping to the action that is “right” (clockwise) of the intended
 
-    These three must sum to 1.0 (the constructor will normalize them if they don’t).  
+    These three must sum to 1.0 (the constructor will normalize them if they don’t).
 
     These parameters are initialized with the following default values when left unspecified:
     chance_correct_action = 1/3
@@ -233,9 +233,9 @@ class FrozenLakeEnv(Env):
         reward_goal=1.0,
         reward_hole=0.0,
         reward_step=0.0,
-        chance_correct_action = 1/3,
-        chance_slip_l = 1/3,
-        chance_slip_r = 1/3
+        chance_correct_action=1 / 3,
+        chance_slip_l=1 / 3,
+        chance_slip_r=1 / 3,
     ):
         if desc is None and map_name is None:
             desc = generate_random_map()
@@ -258,7 +258,9 @@ class FrozenLakeEnv(Env):
         total = sum(probs)
         if not np.isclose(total, 1.0):
             # Normalize to sum exactly to 1.0
-            chance_correct_action, chance_slip_l, chance_slip_r = [p/total for p in probs]
+            chance_correct_action, chance_slip_l, chance_slip_r = (
+                p / total for p in probs
+            )
         self.chance_correct_action = chance_correct_action
         self.chance_slip_l = chance_slip_l
         self.chance_slip_r = chance_slip_r
@@ -310,14 +312,12 @@ class FrozenLakeEnv(Env):
                     else:
                         if is_slippery:
                             probs = {
-                                (a - 1) % 4 : self.chance_slip_l,
-                                a           : self.chance_correct_action,
-                                (a + 1) % 4 : self.chance_slip_r
+                                (a - 1) % 4: self.chance_slip_l,
+                                a: self.chance_correct_action,
+                                (a + 1) % 4: self.chance_slip_r,
                             }
                             for b, p in probs.items():
-                                li.append(
-                                    (p, *update_probability_matrix(row, col, b))
-                                )
+                                li.append((p, *update_probability_matrix(row, col, b)))
                         else:
                             li.append((1.0, *update_probability_matrix(row, col, a)))
 

--- a/gymnasium/envs/toy_text/frozen_lake.py
+++ b/gymnasium/envs/toy_text/frozen_lake.py
@@ -126,9 +126,9 @@ class FrozenLakeEnv(Env):
 
     ## Rewards
     The rewards given at each state can be overridden by passing into the constructor:
-    - Reach goal default: +1.0
-    - Reach hole default: 0.0
-    - Make step: 0.0 (always applied to any action)
+    - 'reward_goal' (default): +1.0
+    - 'reward_hole' (default): 0.0
+    - 'reward_step' (default): 0.0 (always applied to any action)
 
     ## Episode End
     The episode ends if the following happens:
@@ -198,14 +198,19 @@ class FrozenLakeEnv(Env):
     If `desc=None` then `map_name` will be used. If both `desc` and `map_name` are
     `None` a random 8x8 map with 80% of locations frozen will be generated.
 
-    <a id="is_slippy"></a>`is_slippery=True`: If true the player will move in intended direction with
-    probability of 1/3 else will move in either perpendicular direction with
-    equal probability of 1/3 in both directions.
+    <a id="is_slippy"></a>`is_slippery=True`: If true, each move is stochastic according
+    to three user-settable probabilities:
 
-    For example, if action is left and is_slippery is True, then:
-    - P(move left)=1/3
-    - P(move up)=1/3
-    - P(move down)=1/3
+    - 'chance_correct_action': probability of moving in the intended direction  
+    - 'chance_slip_l': probability of slipping to the action that is “left” (counter-clockwise) of the intended  
+    - 'chance_slip_r': probability of slipping to the action that is “right” (clockwise) of the intended  
+
+    These three must sum to 1.0 (the constructor will normalize them if they don’t).  
+
+    These parameters are initialized with the following default values when left unspecified:
+    chance_correct_action = 1/3
+    chance_slip_l = 1/3
+    chance_slip_r = 1/3
 
 
     ## Version History

--- a/tests/envs/test_envs.py
+++ b/tests/envs/test_envs.py
@@ -1,8 +1,8 @@
 import pickle
 import re
 import warnings
-import numpy as np
 
+import numpy as np
 import pytest
 
 import gymnasium as gym
@@ -204,15 +204,12 @@ def test_frozenlake_custom_rewards_and_range(reward_goal, reward_hole, reward_st
     assert next_state == 2 and r == (reward_hole + reward_step) and done
 
 
-
-@pytest.mark.parametrize("chance_correct, chance_l, chance_r", [
-    (0.6, 0.2, 0.2),
-    (0.8, 0.1, 0.1),
-    (1/3, 1/3, 1/3),
-    (.4, .4, .4)
-])
+@pytest.mark.parametrize(
+    "chance_correct, chance_l, chance_r",
+    [(0.6, 0.2, 0.2), (0.8, 0.1, 0.1), (1 / 3, 1 / 3, 1 / 3), (0.4, 0.4, 0.4)],
+)
 def test_frozenlake_slip_probabilities(chance_correct, chance_l, chance_r):
-    desc = ["FFF","SFG","FFF"]  # positions 0=S, 1=F, 2=G
+    desc = ["FFF", "SFG", "FFF"]  # positions 0=S, 1=F, 2=G
     raw = gym.make(
         "FrozenLake-v1",
         desc=desc,
@@ -230,7 +227,7 @@ def test_frozenlake_slip_probabilities(chance_correct, chance_l, chance_r):
     action = 2  # RIGHT
 
     transitions = env.P[start][action]
-    declared_probs = {next_state: prob for (prob, next_state, *_ ) in transitions}
+    declared_probs = {next_state: prob for (prob, next_state, *_) in transitions}
 
     # sanity check: they must sum to 1
     assert np.isclose(sum(declared_probs.values()), 1.0)
@@ -238,22 +235,22 @@ def test_frozenlake_slip_probabilities(chance_correct, chance_l, chance_r):
     # initialize counts for exactly those next_states
     counts = {s: 0 for s in declared_probs}
     # starting from 3:
-        # slip down (left) -> 6,
-        # slip down (right) -> 0
-        # correct aciton, right (forward) -> 4
-    
+    # slip down (left) -> 6,
+    # slip down (right) -> 0
+    # correct aciton, right (forward) -> 4
+
     n = 20000
     for _ in range(n):
         env.s = start
         s, *_ = env.step(action)
         counts[s] += 1
 
-    freqs = {s: counts[s]/n for s in counts}
+    freqs = {s: counts[s] / n for s in counts}
 
     # allow a ±3% tolerance
     tol = 0.03
     for s, p_declared in declared_probs.items():
         p_obs = freqs[s]
-        assert abs(p_obs - p_declared) < tol, (
-            f"State {s}: observed {p_obs:.3f}, declared {p_declared:.3f}"
-        )
+        assert (
+            abs(p_obs - p_declared) < tol
+        ), f"State {s}: observed {p_obs:.3f}, declared {p_declared:.3f}"

--- a/tests/envs/test_envs.py
+++ b/tests/envs/test_envs.py
@@ -237,7 +237,7 @@ def test_frozenlake_slip_probabilities(chance_correct, chance_l, chance_r):
     # starting from 3:
     # slip down (left) -> 6,
     # slip down (right) -> 0
-    # correct aciton, right (forward) -> 4
+    # correct action, right (forward) -> 4
 
     n = 20000
     for _ in range(n):

--- a/tests/envs/test_envs.py
+++ b/tests/envs/test_envs.py
@@ -209,6 +209,7 @@ def test_frozenlake_custom_rewards_and_range(reward_goal, reward_hole, reward_st
     (0.6, 0.2, 0.2),
     (0.8, 0.1, 0.1),
     (1/3, 1/3, 1/3),
+    (.4, .4, .4)
 ])
 def test_frozenlake_slip_probabilities(chance_correct, chance_l, chance_r):
     desc = ["FFF","SFG","FFF"]  # positions 0=S, 1=F, 2=G
@@ -251,9 +252,8 @@ def test_frozenlake_slip_probabilities(chance_correct, chance_l, chance_r):
 
     # allow a ±3% tolerance
     tol = 0.03
-    assert abs(freqs[4] - chance_correct) < tol, \
-        f"correct_action freq {freqs[4]:.3f} vs target {chance_correct}"
-    assert abs(freqs[6] - chance_l) < tol, \
-        f"slip_l freq {freqs[6]:.3f} vs target {chance_l}"
-    assert abs(freqs[0] - chance_r) < tol, \
-        f"slip_r freq {freqs[0]:.3f} vs target {chance_r}"
+    for s, p_declared in declared_probs.items():
+        p_obs = freqs[s]
+        assert abs(p_obs - p_declared) < tol, (
+            f"State {s}: observed {p_obs:.3f}, declared {p_declared:.3f}"
+        )


### PR DESCRIPTION
# Description

This branch adds three new initialization parameters to `FrozenLakeEnv`—`chance_correct_action`, `chance_slip_l`, and `chance_slip_r`—to allow fine-grained control over slip behavior. Instead of assuming equal probabilities for slipping left, right, and moving forward, users can now customize these probabilities to better match specific experimental setups or testing needs. Defaults preserve the original 1/3–1/3–1/3 behavior, and the parameters are normalized internally if needed.

Fixes #1365

- Added the ability to customize slip probabilities for correct movement and left/right slips independently.
- Extended the environment docstring with updated slipping mechanics documentation and examples.
- Added unit tests to verify observed slip frequencies match user-specified probabilities.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

### Screenshots

N/A

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
